### PR TITLE
feat: 대시보드 토픽 분포에서 내부 토픽 정확히 표시

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,40 +1,42 @@
-.gradle/
-.vscode/
-node_modules/
-pnpm-lock.yaml
-.env
-.vite/
-build/
-bin/
-.idea/
-out/
-*.iml
+*.md
 HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+*.db
 
-# Compiled class file
-*.class
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
 
-# Log file
-*.log
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
 
-# BlueJ files
-*.ctxt
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
 
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
+### VS Code ###
+.vscode/
 
-# Package Files #
-*.jar
-*.war
-*.nar
-*.ear
-*.zip
-*.tar.gz
-*.rar
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
-replay_pid*
-
-# Kotlin Gradle plugin data, see https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects
-.kotlin/
+### Kotlin ###
+.kotlin

--- a/KAFKA_KOPANDA/src/main/kotlin/com/sleekydz86/kopanda/application/ports/in/KafkaManagementUseCase.kt
+++ b/KAFKA_KOPANDA/src/main/kotlin/com/sleekydz86/kopanda/application/ports/in/KafkaManagementUseCase.kt
@@ -26,6 +26,8 @@ interface KafkaManagementUseCase {
     suspend fun createTestConsumerGroup(connectionId: String, topicName: String): ConsumerGroupDto
     suspend fun getMetrics(connectionId: String): KafkaMetricsDto
 
+    suspend fun getTopicMetrics(connectionId: String): TopicMetricsDto
+
     suspend fun getDetailedMetrics(connectionId: String): DetailedMetricsDto
     suspend fun getTopicHealth(connectionId: String, topicName: String): TopicHealthDto
     suspend fun getAllTopicsHealth(connectionId: String): List<TopicHealthDto>

--- a/KAFKA_KOPANDA/src/main/kotlin/com/sleekydz86/kopanda/application/services/KafkaApplicationService.kt
+++ b/KAFKA_KOPANDA/src/main/kotlin/com/sleekydz86/kopanda/application/services/KafkaApplicationService.kt
@@ -427,6 +427,11 @@ class KafkaApplicationService(
         return kafkaRepository.getMetrics(connection)
     }
 
+    override suspend fun getTopicMetrics(connectionId: String): TopicMetricsDto {
+        val connection = getConnectionOrThrow(connectionId)
+        return kafkaRepository.getTopicMetrics(connection)
+    }
+
     override suspend fun getDetailedMetrics(connectionId: String): DetailedMetricsDto {
         val connection = getConnectionOrThrow(connectionId)
         return kafkaRepository.getDetailedMetrics(connection)

--- a/KAFKA_KOPANDA/src/main/kotlin/com/sleekydz86/kopanda/infrastructure/adapters/in/rest/MonitoringController.kt
+++ b/KAFKA_KOPANDA/src/main/kotlin/com/sleekydz86/kopanda/infrastructure/adapters/in/rest/MonitoringController.kt
@@ -1174,4 +1174,70 @@ class MonitoringController(
 
         return ResponseEntity.ok(dashboardData)
     }
+
+    @GetMapping("/connections/{connectionId}/topic-metrics")
+    @Operation(
+        summary = "토픽 메트릭 조회",
+        description = "지정된 Kafka 연결의 토픽 메트릭을 조회합니다. 총 토픽 수, 내부 토픽 수, 사용자 토픽 수, 파티션 정보 등을 포함합니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "토픽 메트릭 조회 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(
+                            implementation = TopicMetricsDto::class,
+                            description = "토픽 메트릭 정보"
+                        )
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "연결을 찾을 수 없음",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(
+                            implementation = ErrorResponse::class,
+                            description = "오류 응답"
+                        )
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "서버 내부 오류",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(
+                            implementation = ErrorResponse::class,
+                            description = "오류 응답"
+                        )
+                    )
+                ]
+            )
+        ]
+    )
+    suspend fun getTopicMetrics(
+        @Parameter(
+            description = "조회할 Kafka 연결의 고유 식별자",
+            example = "conn_001",
+            schema = Schema(
+                type = "string",
+                pattern = "^[a-zA-Z0-9_-]+$",
+                minLength = 1,
+                maxLength = 50
+            )
+        )
+        @PathVariable connectionId: String
+    ): ResponseEntity<TopicMetricsDto> {
+        val connection = connectionManagementUseCase.getConnection(connectionId)
+        val topicMetrics = kafkaManagementUseCase.getTopicMetrics(connectionId)
+        return ResponseEntity.ok(topicMetrics)
+    }
 }


### PR DESCRIPTION
- GET /monitoring/connections/{id}/topic-metrics API 추가
- KafkaManagementUseCase에 getTopicMetrics 메서드 추가
- KafkaApplicationService에 getTopicMetrics 구현